### PR TITLE
Don't compress or generate sourcemaps for webpack bundles

### DIFF
--- a/lib/sprockets_uglifier_with_source_maps/compressor.rb
+++ b/lib/sprockets_uglifier_with_source_maps/compressor.rb
@@ -15,7 +15,14 @@ module SprocketsUglifierWithSM
       data = input.fetch(:data)
       name = input.fetch(:name)
 
-      if /sourceMappingURL=data:application\/json;charset=utf-8;base64/.match(data).present?
+      if name.include? '-bundle'
+        # Each webpack bundle already has a corresponding sourcemap, so let's use that
+        sourcemap_json = File.read("#{input[:filename]}.map").to_json
+
+        # Each webpack bundle is already minified, so let's only strip the existing
+        # sourcemap reference; we'll replace it with a fingerprinted version below.
+        compressed_data = data.sub(/\/\/# sourceMappingURL=.*$/, '').rstrip
+      elsif /sourceMappingURL=data:application\/json;charset=utf-8;base64/.match(data).present?
         extra_options = {
           source_map: {
             :input_source_map => 'inline',

--- a/lib/sprockets_uglifier_with_source_maps/version.rb
+++ b/lib/sprockets_uglifier_with_source_maps/version.rb
@@ -1,3 +1,3 @@
 module SprocketsUglifierWithSM
-  VERSION = '2.2.0'
+  VERSION = '2.3.0'
 end


### PR DESCRIPTION
Webpack bundles are already minified and have back-to-the-original-file
level sourcemaps by the time this sprockets compressor is run, so let's
just use those.

Test Plan:

Clone this repo as a sibling of academia-app.
In academia-app, change the Gemfile to have the following line:

```
gem 'sprockets_uglifier_with_source_maps', '>= 2.3.0', :path => '../sprockets_uglifier_with_source_maps'
```

In academia-app, run the following command:

```
RAILS_ENV=asset_compilation RECOMPILE_ASSETS_WITHOUT_TMP=true bundle exec rake assets:generate_and_precompile
```

Inspect the ouptut in public/assets/webpack_bundles and
public/assets/maps/webpack_bundles, confirm expected results (js content
is what got output by webpack, sourcemap reference is correct, sourcemap
exists).